### PR TITLE
docs: centralize and improve options types and documentation

### DIFF
--- a/lib/gemini.ex
+++ b/lib/gemini.ex
@@ -166,6 +166,37 @@ defmodule Gemini do
   alias Gemini.Types.Content
   alias Gemini.Types.Response.GenerateContentResponse
 
+  @typedoc """
+  Options for content generation and related API calls.
+
+  - `:model` - Model name (string, defaults to "gemini-2.0-flash")
+  - `:generation_config` - GenerationConfig struct (`Gemini.Types.GenerationConfig.t()`)
+  - `:safety_settings` - List of SafetySetting structs (`[Gemini.Types.SafetySetting.t()]`)
+  - `:system_instruction` - System instruction as Content struct or string (`Gemini.Types.Content.t() | String.t() | nil`)
+  - `:tools` - List of tool definitions (`[map()]`)
+  - `:tool_config` - Tool configuration (`map() | nil`)
+  - `:api_key` - Override API key (string)
+  - `:auth` - Authentication strategy (`:gemini | :vertex_ai`)
+  - `:temperature` - Generation temperature (float, 0.0-1.0)
+  - `:max_output_tokens` - Maximum tokens to generate (non_neg_integer)
+  - `:top_p` - Top-p sampling parameter (float)
+  - `:top_k` - Top-k sampling parameter (non_neg_integer)
+  """
+  @type options :: [
+          model: String.t(),
+          generation_config: Gemini.Types.GenerationConfig.t() | nil,
+          safety_settings: [Gemini.Types.SafetySetting.t()],
+          system_instruction: Gemini.Types.Content.t() | String.t() | nil,
+          tools: [map()],
+          tool_config: map() | nil,
+          api_key: String.t(),
+          auth: :gemini | :vertex_ai,
+          temperature: float(),
+          max_output_tokens: non_neg_integer(),
+          top_p: float(),
+          top_k: non_neg_integer()
+        ]
+
   @doc """
   Configure authentication for the client.
 
@@ -189,8 +220,10 @@ defmodule Gemini do
 
   @doc """
   Generate content using the configured authentication.
+
+  See `t:Gemini.options/0` for available options.
   """
-  @spec generate(String.t() | [Content.t()], keyword()) ::
+  @spec generate(String.t() | [Content.t()], options()) ::
           {:ok, GenerateContentResponse.t()} | {:error, Error.t()}
   def generate(contents, opts \\ []) do
     Coordinator.generate_content(contents, opts)
@@ -198,8 +231,10 @@ defmodule Gemini do
 
   @doc """
   Generate text content and return only the text.
+
+  See `t:Gemini.options/0` for available options.
   """
-  @spec text(String.t() | [Content.t()], keyword()) :: {:ok, String.t()} | {:error, Error.t()}
+  @spec text(String.t() | [Content.t()], options()) :: {:ok, String.t()} | {:error, Error.t()}
   def text(contents, opts \\ []) do
     case Coordinator.generate_content(contents, opts) do
       {:ok, response} -> Coordinator.extract_text(response)
@@ -209,8 +244,10 @@ defmodule Gemini do
 
   @doc """
   List available models.
+
+  See `t:Gemini.options/0` for available options.
   """
-  @spec list_models(keyword()) :: {:ok, map()} | {:error, Error.t()}
+  @spec list_models(options()) :: {:ok, map()} | {:error, Error.t()}
   def list_models(opts \\ []) do
     Coordinator.list_models(opts)
   end
@@ -225,16 +262,20 @@ defmodule Gemini do
 
   @doc """
   Count tokens in the given content.
+
+  See `t:Gemini.options/0` for available options.
   """
-  @spec count_tokens(String.t() | [Content.t()], keyword()) :: {:ok, map()} | {:error, Error.t()}
+  @spec count_tokens(String.t() | [Content.t()], options()) :: {:ok, map()} | {:error, Error.t()}
   def count_tokens(contents, opts \\ []) do
     Coordinator.count_tokens(contents, opts)
   end
 
   @doc """
   Start a new chat session.
+
+  See `t:Gemini.options/0` for available options.
   """
-  @spec chat(keyword()) :: {:ok, map()}
+  @spec chat(options()) :: {:ok, map()}
   def chat(opts \\ []) do
     {:ok, %{history: [], opts: opts}}
   end
@@ -268,8 +309,10 @@ defmodule Gemini do
 
   @doc """
   Start a managed streaming session.
+
+  See `t:Gemini.options/0` for available options.
   """
-  @spec start_stream(String.t() | [Content.t()], keyword()) ::
+  @spec start_stream(String.t() | [Content.t()], options()) ::
           {:ok, String.t()} | {:error, Error.t()}
   def start_stream(contents, opts \\ []) do
     Coordinator.stream_generate_content(contents, opts)
@@ -338,8 +381,10 @@ defmodule Gemini do
 
   @doc """
   Generate content with streaming response (synchronous collection).
+
+  See `t:Gemini.options/0` for available options.
   """
-  @spec stream_generate(String.t() | [Content.t()], keyword()) ::
+  @spec stream_generate(String.t() | [Content.t()], options()) ::
           {:ok, [map()]} | {:error, Error.t()}
   def stream_generate(contents, opts \\ []) do
     case start_stream(contents, opts) do

--- a/lib/gemini/apis/coordinator.ex
+++ b/lib/gemini/apis/coordinator.ex
@@ -27,6 +27,8 @@ defmodule Gemini.APIs.Coordinator do
 
       # Start streaming with specific auth
       {:ok, stream_id} = Coordinator.stream_generate_content("Tell me a story", auth: :gemini)
+
+  See `t:Gemini.options/0` in `Gemini` for the canonical list of options.
   """
 
   alias Gemini.Client.HTTP
@@ -44,18 +46,11 @@ defmodule Gemini.APIs.Coordinator do
   @doc """
   Generate content using the specified model and input.
 
+  See `t:Gemini.options/0` for available options.
+
   ## Parameters
   - `input`: String prompt or GenerateContentRequest struct
   - `opts`: Options including model, auth strategy, and generation config
-
-  ## Options
-  - `:model`: Model to use (defaults to "gemini-2.0-flash")
-  - `:auth`: Authentication strategy (`:gemini` or `:vertex_ai`)
-  - `:temperature`: Generation temperature (0.0-1.0)
-  - `:max_output_tokens`: Maximum tokens to generate
-  - `:top_p`: Top-p sampling parameter
-  - `:top_k`: Top-k sampling parameter
-  - `:safety_settings`: List of safety settings
 
   ## Examples
 
@@ -74,7 +69,10 @@ defmodule Gemini.APIs.Coordinator do
       request = %GenerateContentRequest{...}
       {:ok, response} = Coordinator.generate_content(request)
   """
-  @spec generate_content(String.t() | [Content.t()] | GenerateContentRequest.t(), request_opts()) ::
+  @spec generate_content(
+          String.t() | [Content.t()] | GenerateContentRequest.t(),
+          Gemini.options()
+        ) ::
           api_result(GenerateContentResponse.t())
   def generate_content(input, opts \\ []) do
     model = Keyword.get(opts, :model, "gemini-2.0-flash")
@@ -91,8 +89,10 @@ defmodule Gemini.APIs.Coordinator do
   @doc """
   Stream content generation with real-time response chunks.
 
+  See `t:Gemini.options/0` for available options.
+
   ## Parameters
-  - `input`: String prompt or GenerateContentRequest struct  
+  - `input`: String prompt or GenerateContentRequest struct
   - `opts`: Options including model, auth strategy, and generation config
 
   ## Returns
@@ -106,11 +106,11 @@ defmodule Gemini.APIs.Coordinator do
 
       # Handle incoming messages
       receive do
-        {:stream_event, ^stream_id, event} -> 
+        {:stream_event, ^stream_id, event} ->
           IO.inspect(event, label: "Stream Event")
-        {:stream_complete, ^stream_id} -> 
+        {:stream_complete, ^stream_id} ->
           IO.puts("Stream completed")
-        {:stream_error, ^stream_id, stream_error} -> 
+        {:stream_error, ^stream_id, stream_error} ->
           IO.puts("Stream error: \#{inspect(stream_error)}")
       end
 
@@ -128,7 +128,7 @@ defmodule Gemini.APIs.Coordinator do
         max_output_tokens: 1000
       )
   """
-  @spec stream_generate_content(String.t() | GenerateContentRequest.t(), request_opts()) ::
+  @spec stream_generate_content(String.t() | GenerateContentRequest.t(), Gemini.options()) ::
           api_result(String.t())
   def stream_generate_content(input, opts \\ []) do
     model = Keyword.get(opts, :model, "gemini-2.0-flash")
@@ -143,7 +143,7 @@ defmodule Gemini.APIs.Coordinator do
   @doc """
   Subscribe to a streaming content generation.
 
-  ## Parameters  
+  ## Parameters
   - `stream_id`: ID of the stream to subscribe to
   - `subscriber_pid`: Process to receive stream events (defaults to current process)
 
@@ -189,6 +189,8 @@ defmodule Gemini.APIs.Coordinator do
   @doc """
   List available models for the specified authentication strategy.
 
+  See `t:Gemini.options/0` for available options.
+
   ## Parameters
   - `opts`: Options including auth strategy and pagination
 
@@ -212,7 +214,7 @@ defmodule Gemini.APIs.Coordinator do
         page_token: "next_page_token"
       )
   """
-  @spec list_models(request_opts()) :: api_result(ListModelsResponse.t())
+  @spec list_models(Gemini.options()) :: api_result(ListModelsResponse.t())
   def list_models(opts \\ []) do
     path = "models"
 
@@ -226,6 +228,8 @@ defmodule Gemini.APIs.Coordinator do
   @doc """
   Get information about a specific model.
 
+  See `t:Gemini.options/0` for available options.
+
   ## Parameters
   - `model_name`: Name of the model to retrieve
   - `opts`: Options including auth strategy
@@ -235,7 +239,7 @@ defmodule Gemini.APIs.Coordinator do
       {:ok, model} = Coordinator.get_model("gemini-2.0-flash")
       {:ok, model} = Coordinator.get_model("gemini-1.5-pro", auth: :vertex_ai)
   """
-  @spec get_model(String.t(), request_opts()) :: api_result(map())
+  @spec get_model(String.t(), Gemini.options()) :: api_result(map())
   def get_model(model_name, opts \\ []) do
     path = "models/#{model_name}"
 
@@ -253,6 +257,8 @@ defmodule Gemini.APIs.Coordinator do
   @doc """
   Count tokens in the given input.
 
+  See `t:Gemini.options/0` for available options.
+
   ## Parameters
   - `input`: String or GenerateContentRequest to count tokens for
   - `opts`: Options including model and auth strategy
@@ -266,7 +272,7 @@ defmodule Gemini.APIs.Coordinator do
       {:ok, count} = Coordinator.count_tokens("Hello world")
       {:ok, count} = Coordinator.count_tokens("Complex text", model: "gemini-1.5-pro", auth: :vertex_ai)
   """
-  @spec count_tokens(String.t() | GenerateContentRequest.t(), request_opts()) ::
+  @spec count_tokens(String.t() | GenerateContentRequest.t(), Gemini.options()) ::
           api_result(%{total_tokens: integer()})
   def count_tokens(input, opts \\ []) do
     model = Keyword.get(opts, :model, "gemini-2.0-flash")
@@ -376,7 +382,7 @@ defmodule Gemini.APIs.Coordinator do
     }
   end
 
-  # Helper function to format Part structs for API requests  
+  # Helper function to format Part structs for API requests
   defp format_part(%{text: text}) when is_binary(text) do
     %{text: text}
   end


### PR DESCRIPTION
- Canonicalize options type in Gemini
- Reference shared type in all relevant docs
- Remove repeated options docs from functions
- Use precise types for all options