### PR TITLE
docs: Add ALTAR integration documentation

### DIFF
--- a/ALTAR_INTEGRATION.md
+++ b/ALTAR_INTEGRATION.md
@@ -1,0 +1,98 @@
+# The Story of Gemini_Ex and ALTAR: A Path to Production
+
+This document tells the story of why `gemini_ex`, a powerful Elixir client for Google's Gemini API, became the first project to integrate with the **ALTAR Productivity Platform**. It's a story about bridging the gap between rapid development and enterprise-grade production readiness, starting with a single, powerful concept: the seamless promotion path.
+
+## The Developer's Dilemma: Building for Today, Scaling for Tomorrow
+
+The AI landscape is evolving at an incredible pace. Frameworks like LangChain, Semantic Kernel, and our own `gemini_ex` make it remarkably easy to build sophisticated AI agents and tools on a local machine. You can prototype, test, and innovate quickly.
+
+But a local prototype is just the first step. The journey to a secure, scalable, and governed enterprise application is fraught with challenges:
+
+-   **Security:** How do you prevent a compromised AI agent from accessing sensitive data or executing unauthorized actions?
+-   **Governance:** How do you enforce access control, audit tool usage, and manage the lifecycle of your tools?
+-   **Scalability:** How do you run tools written in different languages (like Python for data science and Elixir for backend logic) and scale them independently?
+-   **Operations:** How do you manage deployments, monitor performance, and handle state for a distributed AI system?
+
+Solving these problems often requires months of custom engineering work, building bespoke infrastructure that distracts from the core mission of delivering value with AI.
+
+This is the exact problem ALTAR was designed to solve.
+
+## ALTAR's Vision: From Local Development to Enterprise Production, Seamlessly
+
+[ALTAR](https://github.com/nshkrdotcom/ALTAR) is a productivity platform designed to bridge this gap. It provides a **seamless promotion path** for your AI tools, allowing you to move from local development to a distributed, enterprise-grade production environment with a simple configuration change.
+
+This is achieved through a three-layer architecture:
+
+1.  **The ALTAR Data Model (ADM): The Universal Contract.** A standardized, interoperable schema for defining tools. This is the foundation that makes everything else possible.
+2.  **The LATER Protocol: The Frictionless On-Ramp.** A protocol for local, in-process tool execution. It's designed for a best-in-class developer experience, allowing you to build and test tools with minimal overhead.
+3.  **The GRID Protocol: The Secure Backend.** A protocol for a distributed, secure, and governed production runtime. GRID handles the hard problems of security, governance, and scalability, so you don't have to.
+
+## Gemini_Ex: The Perfect First Step
+
+When we built `gemini_ex`, we wanted to provide the most powerful and developer-friendly tool-calling system possible. We needed a way to define, register, and execute tools within the Elixir ecosystem.
+
+We found our answer in ALTAR.
+
+**`gemini_ex` is the first project to implement the `LATER` protocol.**
+
+By adopting ALTAR's `LATER` protocol and its underlying `ADM` data model, we gained several key advantages:
+
+1.  **A Standardized Contract:** Instead of inventing our own tool definition format, we adopted the ADM. This industry-standard contract, based on patterns from Google and OpenAPI, ensures our tools are interoperable and future-proof.
+2.  **A Clear Path Forward:** The integration isn't just about local execution; it's about a vision for the future. Our users can build tools with `gemini_ex` today, knowing that there is a clear, defined path to deploying them in a secure, enterprise-grade environment using ALTAR's `GRID` protocol tomorrow.
+3.  **Focus on Core Competency:** Integrating with ALTAR allowed us to focus on what `gemini_ex` does best: providing a world-class Elixir interface to the Gemini API. We get a robust tool definition and execution model without having to build it from scratch.
+
+### How it Works Today: The `LATER` Implementation
+
+Currently, `gemini_ex` leverages the `LATER` protocol for all its tool-calling capabilities. When you define and register a tool in `gemini_ex`, you are using the ALTAR Data Model. When the model decides to call a function, the execution is handled by our local `LATER`-compliant runtime.
+
+```elixir
+# 1. You define a tool using the ALTAR Data Model (ADM)
+{:ok, weather_declaration} = Altar.ADM.new_function_declaration(%{
+  name: "get_weather",
+  description: "Gets the current weather for a specified location.",
+  parameters: %{
+    type: "object",
+    properties: %{location: %{type: "string"}}
+  }
+})
+
+# 2. You register it with the local LATER-compliant registry
+Gemini.Tools.register(weather_declaration, &MyApp.Tools.get_weather/1)
+
+# 3. The LATER executor handles the local function call
+{:ok, response} = Gemini.generate_content_with_auto_tools(
+  "What's the weather like in Tokyo?",
+  tools: [weather_declaration]
+)
+```
+
+This provides a fantastic developer experience for building and testing AI agents. But it's just the beginning of the story.
+
+## The Roadmap: From `LATER` to `GRID`
+
+The integration of the `LATER` protocol into `gemini_ex` is the first, crucial step in proving the ALTAR concept. The next phase of our roadmap is to complete the full build-out of the ALTAR platform, including the `GRID` protocol, and then integrate it into `gemini_ex`.
+
+**What does this mean for `gemini_ex` users?**
+
+Imagine a future where you can take the exact same tool you developed and tested locally with `gemini_ex` and deploy it to a secure, scalable production environment with a single configuration change.
+
+```elixir
+# In development (config/dev.exs)
+config :gemini_ex,
+  tool_source: :later
+
+# In production (config/prod.exs)
+config :gemini_ex,
+  tool_source: {:grid, [host: "grid.mycompany.com", port: 8080]}
+```
+
+With this change, your tool executions would no longer run in-process with your Elixir application. Instead, they would be securely dispatched to the **ALTAR GRID**, a managed environment that provides:
+
+-   **Centralized Governance:** Enforce access control and audit every tool call.
+-   **Polyglot Runtimes:** Run your Python data science tools alongside your Elixir backend tools, each in its own optimized environment.
+-   **Host-Centric Security:** The GRID Host, not the runtime, is the source of truth for tool contracts, preventing a wide range of vulnerabilities.
+-   **Independent Scalability:** Scale your AI tools independently of your main application, optimizing resource usage and cost.
+
+This is the power of the "promotion path." You get the best of both worlds: the speed and agility of local development, and the security and scale of an enterprise-grade production environment, all without rewriting your code.
+
+The journey has just begun, but by integrating `LATER` into `gemini_ex`, we've laid the foundation for a new era of AI productivity.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ A comprehensive Elixir client for Google's Gemini AI API with dual authenticatio
 - **🚀 Production Ready**: Robust error handling, retry logic, and performance optimizations
 - **🔧 Flexible Configuration**: Environment variables, application config, and per-request overrides
 
+## 🔗 ALTAR Integration: The Path to Production
+
+`gemini_ex` is the first project to integrate with the **ALTAR Productivity Platform**, a system designed to bridge the gap between local AI development and enterprise-grade production deployment.
+
+We've adopted ALTAR's `LATER` protocol to provide a best-in-class local tool-calling experience. This is the first step in a long-term vision to offer a seamless "promotion path" for your AI tools, from local testing to a secure, scalable, and governed production environment via ALTAR's `GRID` protocol.
+
+**[➡️ Learn the full story behind our integration in `ALTAR_INTEGRATION.md`](ALTAR_INTEGRATION.md)**
+
 ## 📦 Installation
 
 Add `gemini` to your list of dependencies in `mix.exs`:

--- a/mix.exs
+++ b/mix.exs
@@ -71,6 +71,7 @@ defmodule Gemini.MixProject do
       homepage_url: @source_url,
       extras: [
         "README.md",
+        "ALTAR_INTEGRATION.md",
         "ARCHITECTURE.md",
         "AUTHENTICATION_SYSTEM.md",
         "STREAMING.md",
@@ -80,7 +81,7 @@ defmodule Gemini.MixProject do
         "CHANGELOG.md"
       ],
       groups_for_extras: [
-        Guides: ["README.md"],
+        Guides: ["README.md", "ALTAR_INTEGRATION.md"],
         Features: [
           "AUTOMATIC_TOOL_EXECUTION.md"
         ],
@@ -176,11 +177,12 @@ defmodule Gemini.MixProject do
       name: "gemini_ex",
       description: description(),
       files:
-        ~w(lib mix.exs README.md ARCHITECTURE.md AUTHENTICATION_SYSTEM.md STREAMING.md STREAMING_ARCHITECTURE.md TELEMETRY_IMPLEMENTATION.md CHANGELOG.md LICENSE),
+        ~w(lib mix.exs README.md ALTAR_INTEGRATION.md ARCHITECTURE.md AUTHENTICATION_SYSTEM.md STREAMING.md STREAMING_ARCHITECTURE.md TELEMETRY_IMPLEMENTATION.md CHANGELOG.md LICENSE),
       licenses: ["MIT"],
       links: %{
         "GitHub" => @source_url,
         "Online documentation" => "https://hexdocs.pm/gemini_ex",
+        "ALTAR Integration Story" => "https://hexdocs.pm/gemini_ex/ALTAR_INTEGRATION.html",
         "Changelog" => "#{@source_url}/blob/main/CHANGELOG.md"
       },
       maintainers: ["nshkrdotcom"],


### PR DESCRIPTION
This commit introduces comprehensive documentation detailing the integration between `gemini_ex` and the ALTAR Productivity Platform.

A new file, `ALTAR_INTEGRATION.md`, has been created to tell the story of the integration, explaining the rationale, the current implementation using the LATER protocol, and the future roadmap towards the GRID protocol.

The main `README.md` has been updated with a new section that briefly introduces the ALTAR integration and links to the detailed story.

The `mix.exs` file has been updated to include `ALTAR_INTEGRATION.md` in the published package files and to add a link to the document on the Hex.pm page, ensuring it is accessible to all users.