### PR TITLE
feat: Add professional project logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/logo.svg" alt="Gemini Elixir Client Logo" width="200" height="200">
+</p>
+
 # Gemini Elixir Client
 
 [![CI](https://github.com/nshkrdotcom/gemini_ex/actions/workflows/elixir.yaml/badge.svg)](https://github.com/nshkrdotcom/gemini_ex/actions/workflows/elixir.yaml)

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,38 @@
+<svg width="200" height="200" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <defs>
+    <linearGradient id="logo-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4e2a8e;" />
+      <stop offset="100%" style="stop-color:#007acc;" />
+    </linearGradient>
+    <filter id="symbol-shadow" height="130%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer>
+        <feFuncA type="linear" slope="0.5"/>
+      </feComponentTransfer>
+      <feMerge>
+        <feMergeNode in="offsetblur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <path
+    d="M 50 0 L 93.3 25 L 93.3 75 L 50 100 L 6.7 75 L 6.7 25 Z"
+    fill="url(#logo-gradient)"
+  />
+
+  <text
+    x="50%"
+    y="50%"
+    font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
+    font-size="50"
+    font-weight="bold"
+    fill="white"
+    text-anchor="middle"
+    dominant-baseline="central"
+    filter="url(#symbol-shadow)"
+  >
+    ♊
+  </text>
+</svg>


### PR DESCRIPTION
This commit introduces a new professional logo for the `gemini_ex` project.

- A new `assets` directory has been created to store project assets.
- A detailed, hex-shaped SVG logo has been designed and added to `assets/logo.svg`. The logo features a purple-to-blue gradient and the Gemini symbol (♊), aligning with the project's identity and Elixir conventions.
- The logo has been added to the top of the `README.md` to improve the project's visual presentation.