### PR TITLE
Add support for :minimal and :medium thinking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
 
+# Local Hex/Mix homes (when HEX_HOME/MIX_HOME are set to the repo)
+/.hex/
+/.mix/
+
 # The directory Mix downloads your dependencies sources to.
 /deps/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -740,7 +740,7 @@ Full support for Google's Gemini 3 model family with new API features:
 - **`thinking_level` Parameter** - New thinking control for Gemini 3 models
   - `GenerationConfig.thinking_level(:low)` - Fast responses, minimal reasoning
   - `GenerationConfig.thinking_level(:high)` - Deep reasoning (default for Gemini 3)
-  - Note: `:medium` is not currently supported by the API
+  - Note: `:minimal` and `:medium` are supported by Gemini 3 Flash (`gemini-3-flash`) but not Gemini 3 Pro
   - Cannot be used with `thinking_budget` in the same request (API returns 400)
 
 - **`gemini-3-pro-image-preview` Model** - Image generation support

--- a/README.md
+++ b/README.md
@@ -1494,6 +1494,19 @@ config = Gemini.Types.GenerationConfig.image_config(
 images = Gemini.Types.Response.Image.extract_base64(response)
 ```
 
+### Thinking Levels (Gemini 3)
+
+Control reasoning behavior with `thinking_level`:
+
+```elixir
+alias Gemini.Types.GenerationConfig
+
+config = GenerationConfig.thinking_level(:low)      # Gemini 3 Pro + Flash
+config = GenerationConfig.thinking_level(:high)     # Gemini 3 Pro + Flash (default)
+config = GenerationConfig.thinking_level(:minimal)  # Gemini 3 Flash only
+config = GenerationConfig.thinking_level(:medium)   # Gemini 3 Flash only
+```
+
 ### Cost Optimization with Thinking Budgets (New in v0.2.2!)
 
 Gemini 2.5 series models use internal "thinking" for complex reasoning. Control thinking token usage to optimize costs:

--- a/docs/20251203/03_THINKING_GAP_ANALYSIS.md
+++ b/docs/20251203/03_THINKING_GAP_ANALYSIS.md
@@ -77,13 +77,13 @@ The GeminiEx library has a **complete implementation** of Gemini's thinking/reas
 
 ## Documentation Notes
 
-### Medium Level Not Supported
+### Gemini 3 Flash-only Levels
 
-**Per Gemini documentation:** `:medium` thinking level is not currently supported by the API.
+**Per Gemini documentation:** Gemini 3 Flash supports additional thinking levels beyond Gemini 3 Pro:
+- `:minimal` and `:medium` are supported by Gemini 3 Flash (`gemini-3-flash`)
+- Gemini 3 Pro supports `:low` and `:high` only
 
-**Our implementation:** The code accepts `:medium` in the typespec but will pass it to the API which may reject it. This matches the documentation's note that medium is "not currently supported."
-
-**Recommendation:** Consider adding a warning when `:medium` is used, or documenting this limitation more prominently.
+**Our implementation:** gemini_ex serializes `thinking_level` to the API `thinkingLevel` field and validates model-specific constraints when using `Gemini.APIs.Coordinator`.
 
 ### Model-Specific Constraints
 

--- a/docs/20251205/request-types/missing_fields.md
+++ b/docs/20251205/request-types/missing_fields.md
@@ -361,7 +361,7 @@ class ThinkingLevel(Enum):
     HIGH = 'HIGH'  # Maximize reasoning depth
 ```
 
-**Note:** gemini_ex correctly documents that `:medium` is not currently supported by the API.
+**Note:** `:minimal` and `:medium` thinking levels are supported by Gemini 3 Flash (`gemini-3-flash`) but not Gemini 3 Pro.
 
 ---
 

--- a/examples/gemini_3_demo.exs
+++ b/examples/gemini_3_demo.exs
@@ -38,10 +38,8 @@ IO.puts(String.duplicate("-", 80) <> "\n")
 
 IO.puts("""
 Gemini 3 introduces `thinking_level` to control reasoning depth:
-- :low  - Fast responses, minimal reasoning (best for simple tasks)
-- :high - Deep reasoning, may have higher latency (default)
-
-Note: :medium is not currently supported.
+- Gemini 3 Pro: :low, :high
+- Gemini 3 Flash: :minimal, :low, :medium, :high
 """)
 
 # Example with low thinking level (fast)

--- a/lib/gemini/types/common/generation_config.ex
+++ b/lib/gemini/types/common/generation_config.ex
@@ -14,9 +14,11 @@ defmodule Gemini.Types.GenerationConfig do
 
     Use `thinking_level` for Gemini 3 models:
     - `:low` - Minimizes latency and cost. Best for simple tasks.
-    - `:high` - Maximizes reasoning depth (default for Gemini 3).
+    - `:high` - Maximizes reasoning depth (default, dynamic)
 
-    Note: `:medium` is not currently supported.
+    Gemini 3 Flash also supports:
+    - `:minimal` - Matches "no thinking" for most queries (minimizes latency)
+    - `:medium` - Balanced thinking for most tasks
 
     ## Gemini 2.5 (Legacy)
 
@@ -33,7 +35,7 @@ defmodule Gemini.Types.GenerationConfig do
 
     use TypedStruct
 
-    @type thinking_level :: :low | :medium | :high
+    @type thinking_level :: :minimal | :low | :medium | :high
 
     @derive Jason.Encoder
     typedstruct do
@@ -229,10 +231,12 @@ defmodule Gemini.Types.GenerationConfig do
   ## Parameters
   - `config`: GenerationConfig struct (defaults to new config)
   - `level`: Thinking level atom
+    - `:minimal` - Gemini 3 Flash only. Matches "no thinking" for most queries.
     - `:low` - Minimizes latency and cost. Best for simple instruction following.
+    - `:medium` - Gemini 3 Flash only. Balanced thinking for most tasks.
     - `:high` - Maximizes reasoning depth. Model may take longer for first token.
 
-  Note: `:medium` is not currently supported by the API.
+  Note: `:minimal` and `:medium` are only supported by Gemini 3 Flash.
 
   ## Important
 
@@ -253,7 +257,8 @@ defmodule Gemini.Types.GenerationConfig do
         |> GenerationConfig.max_tokens(1000)
   """
   @spec thinking_level(t(), ThinkingConfig.thinking_level()) :: t()
-  def thinking_level(config \\ %__MODULE__{}, level) when level in [:low, :medium, :high] do
+  def thinking_level(config \\ %__MODULE__{}, level)
+      when level in [:minimal, :low, :medium, :high] do
     thinking_config = %ThinkingConfig{thinking_level: level}
     %{config | thinking_config: thinking_config}
   end

--- a/test/gemini/apis/coordinator_generation_config_new_fields_test.exs
+++ b/test/gemini/apis/coordinator_generation_config_new_fields_test.exs
@@ -53,6 +53,22 @@ defmodule Gemini.APIs.CoordinatorGenerationConfigNewFieldsTest do
                "outputCompressionQuality" => 80
              }
     end
+
+    test "includes thinking_config thinking_level for Gemini 3 Flash (minimal/medium)" do
+      config_minimal =
+        Coordinator.__test_build_generation_config__(
+          thinking_config: %{thinking_level: :minimal}
+        )
+
+      assert config_minimal["thinkingConfig"] == %{"thinkingLevel" => "minimal"}
+
+      config_medium =
+        Coordinator.__test_build_generation_config__(
+          thinking_config: %{thinking_level: :medium}
+        )
+
+      assert config_medium["thinkingConfig"] == %{"thinkingLevel" => "medium"}
+    end
   end
 
   describe "__test_struct_to_api_map__/1" do
@@ -113,6 +129,29 @@ defmodule Gemini.APIs.CoordinatorGenerationConfigNewFieldsTest do
                "outputMimeType" => "image/png",
                "outputCompressionQuality" => 90
              }
+    end
+
+    test "encodes thinking_config thinking_level on struct (minimal/medium)" do
+      gc_minimal = %GenerationConfig{
+        thinking_config: %GenerationConfig.ThinkingConfig{thinking_level: :minimal}
+      }
+
+      result_minimal = Coordinator.__test_struct_to_api_map__(gc_minimal)
+
+      thinking_config =
+        Map.get(result_minimal, "thinkingConfig") || Map.get(result_minimal, :thinkingConfig)
+
+      assert thinking_config == %{"thinkingLevel" => "minimal"}
+
+      gc_medium = %GenerationConfig{
+        thinking_config: %GenerationConfig.ThinkingConfig{thinking_level: :medium}
+      }
+
+      result_medium = Coordinator.__test_struct_to_api_map__(gc_medium)
+
+      thinking_config = Map.get(result_medium, "thinkingConfig") || Map.get(result_medium, :thinkingConfig)
+
+      assert thinking_config == %{"thinkingLevel" => "medium"}
     end
   end
 end

--- a/test/gemini/types/common/generation_config_thinking_test.exs
+++ b/test/gemini/types/common/generation_config_thinking_test.exs
@@ -4,6 +4,36 @@ defmodule Gemini.Types.GenerationConfigThinkingTest do
   alias Gemini.Types.GenerationConfig
   alias Gemini.Types.GenerationConfig.ThinkingConfig
 
+  describe "thinking_level/2" do
+    test "creates config with minimal thinking (Gemini 3 Flash)" do
+      config = GenerationConfig.thinking_level(:minimal)
+
+      assert config.thinking_config.thinking_level == :minimal
+      assert config.thinking_config.thinking_budget == nil
+    end
+
+    test "creates config with low thinking" do
+      config = GenerationConfig.thinking_level(:low)
+
+      assert config.thinking_config.thinking_level == :low
+      assert config.thinking_config.thinking_budget == nil
+    end
+
+    test "creates config with medium thinking (Gemini 3 Flash)" do
+      config = GenerationConfig.thinking_level(:medium)
+
+      assert config.thinking_config.thinking_level == :medium
+      assert config.thinking_config.thinking_budget == nil
+    end
+
+    test "creates config with high thinking" do
+      config = GenerationConfig.thinking_level(:high)
+
+      assert config.thinking_config.thinking_level == :high
+      assert config.thinking_config.thinking_budget == nil
+    end
+  end
+
   describe "thinking_budget/2" do
     test "creates config with disabled thinking (budget = 0)" do
       config = GenerationConfig.thinking_budget(0)

--- a/test/gemini/validation/thinking_config_test.exs
+++ b/test/gemini/validation/thinking_config_test.exs
@@ -116,6 +116,34 @@ defmodule Gemini.Validation.ThinkingConfigTest do
     end
   end
 
+  describe "validate_level/2 for Gemini 3 models" do
+    test "Gemini 3 Pro supports :low and :high only" do
+      assert :ok = ThinkingConfig.validate_level(:low, "gemini-3-pro-preview")
+      assert :ok = ThinkingConfig.validate_level(:high, "gemini-3-pro-preview")
+
+      assert {:error, msg} = ThinkingConfig.validate_level(:medium, "gemini-3-pro-preview")
+      assert msg =~ "only supported by Gemini 3 Flash"
+
+      assert {:error, msg} = ThinkingConfig.validate_level(:minimal, "gemini-3-pro-preview")
+      assert msg =~ "only supported by Gemini 3 Flash"
+    end
+
+    test "Gemini 3 Flash supports :minimal, :low, :medium, and :high" do
+      assert :ok = ThinkingConfig.validate_level(:minimal, "gemini-3-flash")
+      assert :ok = ThinkingConfig.validate_level(:low, "gemini-3-flash")
+      assert :ok = ThinkingConfig.validate_level(:medium, "gemini-3-flash")
+      assert :ok = ThinkingConfig.validate_level(:high, "gemini-3-flash")
+
+      assert {:error, msg} = ThinkingConfig.validate_level(:invalid, "gemini-3-flash")
+      assert msg =~ "Use :minimal, :low, :medium, or :high"
+    end
+
+    test "validate/2 uses model-specific thinking level rules" do
+      assert :ok = ThinkingConfig.validate(%{thinking_level: :medium}, "gemini-3-flash")
+      assert {:error, _msg} = ThinkingConfig.validate(%{thinking_level: :medium}, "gemini-3-pro-preview")
+    end
+  end
+
   describe "validate/2 with config map" do
     test "validates budget in config map" do
       config = %{thinking_budget: 1024}


### PR DESCRIPTION
Adds support for new flash-only thinking levels (minimal, medium) when model is set to flash-3

Closes https://github.com/nshkrdotcom/gemini_ex/issues/15