### PR TITLE
Update ServerContent and UsageMetadata live types

### DIFF
--- a/lib/gemini/types/live/server_content.ex
+++ b/lib/gemini/types/live/server_content.ex
@@ -16,6 +16,7 @@ defmodule Gemini.Types.Live.ServerContent do
   - `input_transcription` - Transcription of input audio
   - `output_transcription` - Transcription of model's audio output
   - `url_context_metadata` - Metadata from URL context retrieval
+  - `turn_complete_reason` - Reason why the turn is complete (`:malformed_function_call`, `:response_rejected`, `:need_more_input`)
 
   ## Example
 
@@ -44,7 +45,8 @@ defmodule Gemini.Types.Live.ServerContent do
           grounding_metadata: GroundingMetadata.t() | nil,
           input_transcription: Transcription.t() | nil,
           output_transcription: Transcription.t() | nil,
-          url_context_metadata: url_context_metadata() | nil
+          url_context_metadata: url_context_metadata() | nil,
+          turn_complete_reason: String.t() | nil
         }
 
   defstruct [
@@ -55,7 +57,8 @@ defmodule Gemini.Types.Live.ServerContent do
     :grounding_metadata,
     :input_transcription,
     :output_transcription,
-    :url_context_metadata
+    :url_context_metadata,
+    :turn_complete_reason
   ]
 
   @doc """
@@ -71,7 +74,8 @@ defmodule Gemini.Types.Live.ServerContent do
       grounding_metadata: Keyword.get(opts, :grounding_metadata),
       input_transcription: Keyword.get(opts, :input_transcription),
       output_transcription: Keyword.get(opts, :output_transcription),
-      url_context_metadata: Keyword.get(opts, :url_context_metadata)
+      url_context_metadata: Keyword.get(opts, :url_context_metadata),
+      turn_complete_reason: Keyword.get(opts, :turn_complete_reason)
     }
   end
 
@@ -91,6 +95,7 @@ defmodule Gemini.Types.Live.ServerContent do
     |> maybe_put("inputTranscription", Transcription.to_api(value.input_transcription))
     |> maybe_put("outputTranscription", Transcription.to_api(value.output_transcription))
     |> maybe_put("urlContextMetadata", convert_url_context_to_api(value.url_context_metadata))
+    |> maybe_put("turnCompleteReason", value.turn_complete_reason)
   end
 
   @doc """
@@ -115,7 +120,8 @@ defmodule Gemini.Types.Live.ServerContent do
         (data["outputTranscription"] || data["output_transcription"])
         |> Transcription.from_api(),
       url_context_metadata:
-        parse_url_context(data["urlContextMetadata"] || data["url_context_metadata"])
+        parse_url_context(data["urlContextMetadata"] || data["url_context_metadata"]),
+      turn_complete_reason: data["turnCompleteReason"] || data["turn_complete_reason"]
     }
   end
 

--- a/lib/gemini/types/live/usage_metadata.ex
+++ b/lib/gemini/types/live/usage_metadata.ex
@@ -17,6 +17,8 @@ defmodule Gemini.Types.Live.UsageMetadata do
   - `cache_tokens_details` - Token counts by modality for cached content
   - `response_tokens_details` - Token counts by modality for response
   - `tool_use_prompt_tokens_details` - Token counts by modality for tool use
+  - `candidates_token_count` - Total tokens across all response candidates
+  - `candidates_tokens_details` - Token counts by modality for candidates
 
   ## Example
 
@@ -42,7 +44,9 @@ defmodule Gemini.Types.Live.UsageMetadata do
           prompt_tokens_details: [modality_token_count()] | nil,
           cache_tokens_details: [modality_token_count()] | nil,
           response_tokens_details: [modality_token_count()] | nil,
-          tool_use_prompt_tokens_details: [modality_token_count()] | nil
+          tool_use_prompt_tokens_details: [modality_token_count()] | nil,
+          candidates_token_count: integer() | nil,
+          candidates_tokens_details: [modality_token_count()] | nil
         }
 
   defstruct [
@@ -55,7 +59,9 @@ defmodule Gemini.Types.Live.UsageMetadata do
     :prompt_tokens_details,
     :cache_tokens_details,
     :response_tokens_details,
-    :tool_use_prompt_tokens_details
+    :tool_use_prompt_tokens_details,
+    :candidates_token_count,
+    :candidates_tokens_details
   ]
 
   @doc """
@@ -73,7 +79,9 @@ defmodule Gemini.Types.Live.UsageMetadata do
       prompt_tokens_details: Keyword.get(opts, :prompt_tokens_details),
       cache_tokens_details: Keyword.get(opts, :cache_tokens_details),
       response_tokens_details: Keyword.get(opts, :response_tokens_details),
-      tool_use_prompt_tokens_details: Keyword.get(opts, :tool_use_prompt_tokens_details)
+      tool_use_prompt_tokens_details: Keyword.get(opts, :tool_use_prompt_tokens_details),
+      candidates_token_count: Keyword.get(opts, :candidates_token_count),
+      candidates_tokens_details: Keyword.get(opts, :candidates_tokens_details)
     }
   end
 
@@ -98,6 +106,11 @@ defmodule Gemini.Types.Live.UsageMetadata do
       "toolUsePromptTokensDetails",
       convert_details_to_api(value.tool_use_prompt_tokens_details)
     )
+    |> maybe_put("candidatesTokenCount", value.candidates_token_count)
+    |> maybe_put(
+      "candidatesTokensDetails",
+      convert_details_to_api(value.candidates_tokens_details)
+    )
   end
 
   @doc """
@@ -121,7 +134,10 @@ defmodule Gemini.Types.Live.UsageMetadata do
       response_tokens_details:
         get_details(data, "responseTokensDetails", "response_tokens_details"),
       tool_use_prompt_tokens_details:
-        get_details(data, "toolUsePromptTokensDetails", "tool_use_prompt_tokens_details")
+        get_details(data, "toolUsePromptTokensDetails", "tool_use_prompt_tokens_details"),
+      candidates_token_count: get_field(data, "candidatesTokenCount", "candidates_token_count"),
+      candidates_tokens_details:
+        get_details(data, "candidatesTokensDetails", "candidates_tokens_details")
     }
   end
 


### PR DESCRIPTION
## Summary

- Add `candidates_token_count` and `candidates_tokens_details` to `Gemini.Types.Live.UsageMetadata` — mirrors the fields already present in `Gemini.Types.Response.UsageMetadata`
- Add `turn_complete_reason` to `Gemini.Types.Live.ServerContent` — Vertex AI v1 field indicating why a turn completed (`MALFORMED_FUNCTION_CALL`, `RESPONSE_REJECTED`, `NEED_MORE_INPUT`)

Both fields are fully wired through `@type t`, `defstruct`, `new/1`, `to_api/1`, and `from_api/1`.